### PR TITLE
License from BSD to CC

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -3,7 +3,7 @@
   <version>0.1.0</version>
   <description>ROS-ified version of gmapping SLAM. Forked from https://openslam.informatik.uni-freiburg.de/data/svn/gmapping/trunk/</description>
   <maintainer email="vincent.rabaud@gmail.com">Vincent Rabaud</maintainer>
-  <license>BSD</license>
+  <license>CreativeCommons-by-nc-sa-2.0</license>
 
   <url type="website">http://openslam.org/gmapping</url>
   <url type="repository">https://github.com/ros-perception/openslam_gmapping</url>


### PR DESCRIPTION
Following [gmapping](https://github.com/ros-perception/slam_gmapping/blob/30bab91de515984888fb96b208382ddc3dbaec96/gmapping/package.xml) package.