### PR TITLE
Fixed for enable compilation on windows

### DIFF
--- a/include/gmapping/grid/array2d.h
+++ b/include/gmapping/grid/array2d.h
@@ -7,6 +7,10 @@
 
 #include <iostream>
 
+#ifdef _WIN32
+#define __PRETTY_FUNCTION__ __FILE__":" << __LINE__
+#endif
+
 namespace GMapping {
 
 template<class Cell, const bool debug=false> class Array2D{

--- a/utils/stat.cpp
+++ b/utils/stat.cpp
@@ -7,6 +7,12 @@
 #include <math.h>
 #include <gmapping/utils/stat.h>
 
+#ifdef _WIN32
+#define srand48(s) srand(s)
+#define drand48() ((((double)rand())*(double)RAND_MAX))
+#define lrand48() rand()
+#endif
+
 namespace GMapping {
 
 #if 0


### PR DESCRIPTION
Hi, i've found some issue during the compilation of gmapping under Windows with visual c++ 2013. The problem comes due to the usage of functions and definition not present in the c++ standard library. I've fix the problem adding a preprocessor ifdef for give an equivalent define.
