### PR TITLE
make it compile with glibc-2.26 with an explicit cast to bool

### DIFF
--- a/gridfastslam/gfsreader.cpp
+++ b/gridfastslam/gfsreader.cpp
@@ -76,7 +76,7 @@ void RawOdometryRecord::read(istream& is){
   is >> pose.y;
   is >> pose.theta;
   time = 0;
-  assert(is);
+  assert(static_cast<bool>(is));
     is >> time;
  
 }


### PR DESCRIPTION
With glibc-2.26, openslam_gmapping failed to compile with:
```
| [...]/gridfastslam/gfsreader.cpp: In member function 'virtual void GMapping::GFSReader::RawOdometryRecord::read(std::istream&)':
| [...]/gridfastslam/gfsreader.cpp:79:3: error: no match for 'operator==' (operand types are 'std::istream {aka std::basic_istream<char>}' and 'int')
|    assert(is);
|    ^
```

Hence, this commit explicitly casts to bool, so that the assert annotation compiles properly again. The issue was discovered during the maintenance of meta-ros, the OpenEmbedded layer for ROS.