### PR TITLE
update License to BSD3

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -3,7 +3,7 @@
   <version>0.1.2</version>
   <description>ROS-ified version of gmapping SLAM. Forked from https://openslam.informatik.uni-freiburg.de/data/svn/gmapping/trunk/</description>
   <maintainer email="vincent.rabaud@gmail.com">Vincent Rabaud</maintainer>
-  <license>CreativeCommons-by-nc-sa-2.0</license>
+  <license>BSD-3-Clause</license>
 
   <url type="website">http://openslam.org/gmapping</url>
   <url type="repository">https://github.com/ros-perception/openslam_gmapping</url>


### PR DESCRIPTION
@vrabaud @mikaelarguedas 
I have noticed that the license of gmapping has been changed from Creative Commons to BSD-3 around August 2016.
(and also have confirmed that with original copyright holder , prof  Grisetti )

https://web.archive.org/web/20160814180046/http://www.openslam.org/gmapping.html
https://web.archive.org/web/20160712185247/http://www.openslam.org/gmapping.html

1. Can we change the license of this package?
2. If so, how can we proceed?
 - difference between original svn vs this package can be seen at https://gist.github.com/k-okada/14e852fa8e4ee4ead2156a1e43f00248, and 79ef0b0 is identical to the code hosted in openslam_gmapping. 
 - Do we need to get all contributor's approval ? or it is ok if authors of this package (Grisetti/Stachniss/Burgard) agreed?

```
git log --format='%an %ae' 79ef0b0^1...HEAD | sort | uniq
$ git log --format='%an %ae' 79ef0b0^1...HEAD | sort | uniq
grisetti grisetti@e621fd74-1227-0410-9a7b-a4db01ea4bbc
Isaac IY Saito 130s@lateeye.net
Michael Ferguson fergs@unboundedrobotics.com
Mike Ferguson mike@vanadiumlabs.com
Vincent Rabaud vincent.rabaud@gmail.com
Vincent Rabaud vrabaud@willowgarage.com
William Woodall william@osrfoundation.org
William Woodall wjwwood@gmail.com
```