### PR TITLE
Enforce check to avoid memory corruption

### DIFF
--- a/scanmatcher/scanmatcher.cpp
+++ b/scanmatcher/scanmatcher.cpp
@@ -560,7 +560,11 @@ void ScanMatcher::setLaserParameters
 	/*if (m_laserAngles)
 		delete [] m_laserAngles;
 	*/
-	assert(beams<LASER_MAXBEAMS);
+	if(beams>LASER_MAXBEAMS) {
+    cerr << "Number of beams (" << beams << ") is larger than maximum supported value (" <<
+      LASER_MAXBEAMS << ")." << endl;
+    exit(-1);
+  }
 	m_laserPose=lpose;
 	m_laserBeams=beams;
 	//m_laserAngles=new double[beams];


### PR DESCRIPTION
Ubuntu 16.04, ROS Kinetic.

gmapping kept crashing when I published high resolution laser scans, it took me a while to figure out why.

The cause of the crash was especially hard to find since memory corruption caused the program to terminate much later than where the corruption occured. Finally, we traced it down to this.

if the laserscan has more beams than LASER_MAXBEAMS, the memcpy operation [here](https://github.com/ros-perception/openslam_gmapping/blob/c716f0192131029b31a49554f8c11353d29819a5/scanmatcher/scanmatcher.cpp#L567) leads to memory corruption. 

Of course, there is an assert a few lines above. However it did not get triggered (is NDEBUG defined somewhere?). I believe this is not specific to me, as I am using the debian distributed ros version of openslam_gmapping.

I'm convinced replacing the assert with an inexpensive if, verbose message, and exit(-1) would be one way to ensure this error does not inconvenience anymore users, though this much is up to you.

Cheers