### PR TITLE
CMakeLists.txt: fix install command (install libs, install includes to corrrect position as well as hxx

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,16 +152,16 @@ target_link_libraries(gridfastslam
 # )
 
 ## Mark executables and/or libraries for installation
-# install(TARGETS ${PROJECT_NAME} ${PROJECT_NAME}_node
-#   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-#   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-#   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-# )
+install(TARGETS utils autoptr_test sensor_base sensor_odometry sensor_range sensor_range log log_test log_plot scanstudio2carmen rdk2carmen configfile configfile_test scanmatcher scanmatch_test icptest gridfastslam gfs2log gfs2rec gfs2neff
+  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
 
 ## Mark cpp header files for installation
-install(DIRECTORY include/${PROJECT_NAME}/
+install(DIRECTORY include/gmapping
   DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION}
-  FILES_MATCHING PATTERN "*.h"
+  FILES_MATCHING PATTERN "*.h*"
   PATTERN ".svn" EXCLUDE
 )
 


### PR DESCRIPTION
version 0.2.0 did not include any lib/include files...

```
$ dpkg -L ros-melodic-openslam-gmapping
/.
/opt
/opt/ros
/opt/ros/melodic
/opt/ros/melodic/lib
/opt/ros/melodic/lib/pkgconfig
/opt/ros/melodic/lib/pkgconfig/openslam_gmapping.pc
/opt/ros/melodic/share
/opt/ros/melodic/share/openslam_gmapping
/opt/ros/melodic/share/openslam_gmapping/cmake
/opt/ros/melodic/share/openslam_gmapping/cmake/openslam_gmappingConfig-version.cmake
/opt/ros/melodic/share/openslam_gmapping/cmake/openslam_gmappingConfig.cmake
/opt/ros/melodic/share/openslam_gmapping/package.xml
/usr
/usr/share
/usr/share/doc
/usr/share/doc/ros-melodic-openslam-gmapping
/usr/share/doc/ros-melodic-openslam-gmapping/changelog.Debian.gz
```