### PR TITLE
Fix DLL installation directory on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,7 +155,7 @@ target_link_libraries(gridfastslam
 install(TARGETS utils autoptr_test sensor_base sensor_odometry sensor_range sensor_range log log_test log_plot scanstudio2carmen rdk2carmen configfile configfile_test scanmatcher scanmatch_test icptest gridfastslam gfs2log gfs2rec gfs2neff
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+  RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION}
 )
 
 ## Mark cpp header files for installation


### PR DESCRIPTION
See http://docs.ros.org/en/lunar/api/catkin/html/howto/format2/building_libraries.html "The runtime destination is used for .dll file on Windows which must be placed in the global bin folder."

The error was detected with RoboStack: https://github.com/RoboStack/ros-noetic/issues/167