### PR TITLE
Generalize ostreams used for console output in GridSlamProcessor

### DIFF
--- a/gridfastslam/gridslamprocessor.cpp
+++ b/gridfastslam/gridslamprocessor.cpp
@@ -17,14 +17,6 @@ const double m_distanceThresholdCheck = 20;
  
 using namespace std;
 
-  GridSlamProcessor::GridSlamProcessor(): m_infoStream(cout){
-    
-    period_ = 5.0;
-    m_obsSigmaGain=1;
-    m_resampleThreshold=0.5;
-    m_minimumScore=0.;
-  }
-  
   GridSlamProcessor::GridSlamProcessor(const GridSlamProcessor& gsp) 
     :last_update_time_(0.0), m_particles(gsp.m_particles), m_infoStream(cout){
     
@@ -91,7 +83,7 @@ using namespace std;
       m_infoStream  << ".done!" <<endl;
   }
   
-  GridSlamProcessor::GridSlamProcessor(std::ostream& infoS): m_infoStream(infoS){
+  GridSlamProcessor::GridSlamProcessor(std::ostream& infoStr, std::ostream errStr): m_infoStream(infoStr), m_errStream(errStr){
     period_ = 5.0;
     m_obsSigmaGain=1;
     m_resampleThreshold=0.5;
@@ -376,19 +368,19 @@ void GridSlamProcessor::setMotionModelParameters
     m_angularDistance+=fabs(move.theta);
     
     // if the robot jumps throw a warning
-    if (m_linearDistance>m_distanceThresholdCheck){
-      cerr << "***********************************************************************" << endl;
-      cerr << "********** Error: m_distanceThresholdCheck overridden!!!! *************" << endl;
-      cerr << "m_distanceThresholdCheck=" << m_distanceThresholdCheck << endl;
-      cerr << "Old Odometry Pose= " << m_odoPose.x << " " << m_odoPose.y 
+    if (m_linearDistance>m_distanceThresholdCheck && m_errStream){
+      m_errStream << "***********************************************************************" << endl;
+      m_errStream << "********** Error: m_distanceThresholdCheck overridden!!!! *************" << endl;
+      m_errStream << "m_distanceThresholdCheck=" << m_distanceThresholdCheck << endl;
+      m_errStream << "Old Odometry Pose= " << m_odoPose.x << " " << m_odoPose.y 
 	   << " " <<m_odoPose.theta << endl;
-      cerr << "New Odometry Pose (reported from observation)= " << relPose.x << " " << relPose.y 
+      m_errStream << "New Odometry Pose (reported from observation)= " << relPose.x << " " << relPose.y 
 	   << " " <<relPose.theta << endl;
-      cerr << "***********************************************************************" << endl;
-      cerr << "** The Odometry has a big jump here. This is probably a bug in the   **" << endl;
-      cerr << "** odometry/laser input. We continue now, but the result is probably **" << endl;
-      cerr << "** crap or can lead to a core dump since the map doesn't fit.... C&G **" << endl;
-      cerr << "***********************************************************************" << endl;
+      m_errStream << "***********************************************************************" << endl;
+      m_errStream << "** The Odometry has a big jump here. This is probably a bug in the   **" << endl;
+      m_errStream << "** odometry/laser input. We continue now, but the result is probably **" << endl;
+      m_errStream << "** crap or can lead to a core dump since the map doesn't fit.... C&G **" << endl;
+      m_errStream << "***********************************************************************" << endl;
     }
     
     m_odoPose=relPose;

--- a/gridfastslam/gridslamprocessor.cpp
+++ b/gridfastslam/gridslamprocessor.cpp
@@ -17,8 +17,15 @@ const double m_distanceThresholdCheck = 20;
  
 using namespace std;
 
+  GridSlamProcessor::GridSlamProcessor(std::ostream& infoStr, std::ostream& errStr): m_infoStream(infoStr), m_errStream(errStr){
+    period_ = 5.0;
+    m_obsSigmaGain=1;
+    m_resampleThreshold=0.5;
+    m_minimumScore=0.;
+  }
+
   GridSlamProcessor::GridSlamProcessor(const GridSlamProcessor& gsp) 
-    :last_update_time_(0.0), m_particles(gsp.m_particles), m_infoStream(cout){
+    :last_update_time_(0.0), m_particles(gsp.m_particles), m_infoStream(gsp.m_infoStream), m_errStream(gsp.m_errStream){
     
     period_ = 5.0;
 
@@ -81,14 +88,6 @@ using namespace std;
     updateTreeWeights(false);
     if (m_infoStream)
       m_infoStream  << ".done!" <<endl;
-  }
-  
-  GridSlamProcessor::GridSlamProcessor(std::ostream& infoStr, std::ostream errStr): m_infoStream(infoStr), m_errStream(errStr){
-    period_ = 5.0;
-    m_obsSigmaGain=1;
-    m_resampleThreshold=0.5;
-    m_minimumScore=0.;
-	
   }
 
   GridSlamProcessor* GridSlamProcessor::clone() const {

--- a/gridfastslam/gridslamprocessor.cpp
+++ b/gridfastslam/gridslamprocessor.cpp
@@ -48,14 +48,15 @@ using namespace std;
     m_linearDistance=gsp.m_linearDistance;
     m_angularDistance=gsp.m_angularDistance;
     m_neff=gsp.m_neff;
-	
-    cerr << "FILTER COPY CONSTRUCTOR" << endl;
-    cerr << "m_odoPose=" << m_odoPose.x << " " <<m_odoPose.y << " " << m_odoPose.theta << endl;
-    cerr << "m_lastPartPose=" << m_lastPartPose.x << " " <<m_lastPartPose.y << " " << m_lastPartPose.theta << endl;
-    cerr << "m_linearDistance=" << m_linearDistance << endl;
-    cerr << "m_angularDistance=" << m_linearDistance << endl;
-    
-		
+
+    if (m_infoStream) {
+        m_infoStream << "FILTER COPY CONSTRUCTOR" << endl;
+        m_infoStream << "m_odoPose=" << m_odoPose.x << " " << m_odoPose.y << " " << m_odoPose.theta << endl;
+        m_infoStream << "m_lastPartPose=" << m_lastPartPose.x << " " << m_lastPartPose.y << " " << m_lastPartPose.theta << endl;
+        m_infoStream << "m_linearDistance=" << m_linearDistance << endl;
+        m_infoStream << "m_angularDistance=" << m_linearDistance << endl;
+    }
+
     m_xmin=gsp.m_xmin;
     m_ymin=gsp.m_ymin;
     m_xmax=gsp.m_xmax;
@@ -71,20 +72,23 @@ using namespace std;
     m_obsSigmaGain=gsp.m_obsSigmaGain;
     
 #ifdef MAP_CONSISTENCY_CHECK
-    cerr << __func__ <<  ": trajectories copy.... ";
+    if (m_infoStream)
+      m_infoStream << __func__ <<  ": trajectories copy.... ";
 #endif
     TNodeVector v=gsp.getTrajectories();
     for (unsigned int i=0; i<v.size(); i++){
 		m_particles[i].node=v[i];
     }
 #ifdef MAP_CONSISTENCY_CHECK
-    cerr <<  "end" << endl;
+    if (m_infoStream)
+      m_infoStream <<  "end" << endl;
 #endif
 
-
-    cerr  << "Tree: normalizing, resetting and propagating weights within copy construction/cloneing ..." ;
+    if (m_infoStream)
+      m_infoStream  << "Tree: normalizing, resetting and propagating weights within copy construction/cloneing ..." ;
     updateTreeWeights(false);
-    cerr  << ".done!" <<endl;
+    if (m_infoStream)
+      m_infoStream  << ".done!" <<endl;
   }
   
   GridSlamProcessor::GridSlamProcessor(std::ostream& infoS): m_infoStream(infoS){
@@ -97,7 +101,8 @@ using namespace std;
 
   GridSlamProcessor* GridSlamProcessor::clone() const {
 # ifdef MAP_CONSISTENCY_CHECK
-    cerr << __func__ << ": performing preclone_fit_test" << endl;
+    if (m_infoStream)
+      m_infoStream << __func__ << ": performing preclone_fit_test" << endl;
     typedef std::map<autoptr< Array2D<PointAccumulator> >::reference* const, int> PointerMap;
     PointerMap pmap;
 	for (ParticleVector::const_iterator it=m_particles.begin(); it!=m_particles.end(); it++){
@@ -116,17 +121,21 @@ using namespace std;
 	    }
 	  }
 	}
-	cerr << __func__ <<  ": Number of allocated chunks" << pmap.size() << endl;
+  if (m_infoStream)
+	  m_infoStream << __func__ <<  ": Number of allocated chunks" << pmap.size() << endl;
 	for(PointerMap::const_iterator it=pmap.begin(); it!=pmap.end(); it++)
 	  assert(it->first->shares==(unsigned int)it->second);
 
-	cerr << __func__ <<  ": SUCCESS, the error is somewhere else" << endl;
+	if (m_infoStream)
+	  m_infoStream << __func__ <<  ": SUCCESS, the error is somewhere else" << endl;
 # endif
 	GridSlamProcessor* cloned=new GridSlamProcessor(*this);
 	
 # ifdef MAP_CONSISTENCY_CHECK
-	cerr << __func__ <<  ": trajectories end" << endl;
-	cerr << __func__ << ": performing afterclone_fit_test" << endl;
+	if (m_infoStream) {
+	  m_infoStream << __func__ <<  ": trajectories end" << endl;
+  	m_infoStream << __func__ << ": performing afterclone_fit_test" << endl;
+  }
 	ParticleVector::const_iterator jt=cloned->m_particles.begin();
 	for (ParticleVector::const_iterator it=m_particles.begin(); it!=m_particles.end(); it++){
 	  const ScanMatcherMap& m1(it->map);
@@ -143,20 +152,24 @@ using namespace std;
 	    }
 	  }
 	}
-	cerr << __func__ <<  ": SUCCESS, the error is somewhere else" << endl;
+	if (m_infoStream)
+	  m_infoStream << __func__ <<  ": SUCCESS, the error is somewhere else" << endl;
 # endif
 	return cloned;
 }
   
   GridSlamProcessor::~GridSlamProcessor(){
-    cerr << __func__ << ": Start" << endl;
-    cerr << __func__ << ": Deleting tree" << endl;
+    if (m_infoStream) {
+  	  m_infoStream << __func__ << ": Start" << endl;
+      m_infoStream << __func__ << ": Deleting tree" << endl;
+    }
     for (std::vector<Particle>::iterator it=m_particles.begin(); it!=m_particles.end(); it++){
 #ifdef TREE_CONSISTENCY_CHECK		
       TNode* node=it->node;
       while(node)
 	node=node->parent;
-      cerr << "@" << endl;
+      if (m_infoStream)
+        m_infoStream << "@" << endl;
 #endif
       if (it->node)
 	delete it->node;
@@ -164,7 +177,8 @@ using namespace std;
     }
     
 # ifdef MAP_CONSISTENCY_CHECK
-    cerr << __func__ << ": performing predestruction_fit_test" << endl;
+    if (m_infoStream)
+      m_infoStream << __func__ << ": performing predestruction_fit_test" << endl;
     typedef std::map<autoptr< Array2D<PointAccumulator> >::reference* const, int> PointerMap;
     PointerMap pmap;
     for (ParticleVector::const_iterator it=m_particles.begin(); it!=m_particles.end(); it++){
@@ -183,10 +197,12 @@ using namespace std;
 	}
       }
     }
-    cerr << __func__ << ": Number of allocated chunks" << pmap.size() << endl;
+    if (m_infoStream)
+      m_infoStream << __func__ << ": Number of allocated chunks" << pmap.size() << endl;
     for(PointerMap::const_iterator it=pmap.begin(); it!=pmap.end(); it++)
       assert(it->first->shares>=(unsigned int)it->second);
-    cerr << __func__ << ": SUCCESS, the error is somewhere else" << endl;
+    if (m_infoStream)
+      m_infoStream << __func__ << ": SUCCESS, the error is somewhere else" << endl;
 # endif
   }
 
@@ -249,7 +265,8 @@ void GridSlamProcessor::setMotionModelParameters
     
     SensorMap::const_iterator laser_it=smap.find(std::string("FLASER"));
     if (laser_it==smap.end()){
-      cerr << "Attempting to load the new carmen log format" << endl;
+      if (m_infoStream)
+        m_infoStream << "Attempting to load the new carmen log format" << endl;
       laser_it=smap.find(std::string("ROBOTLASER1"));
       assert(laser_it!=smap.end());
     }
@@ -391,16 +408,14 @@ void GridSlamProcessor::setMotionModelParameters
 	m_outputStream << " " << m_linearDistance;
 	m_outputStream << " " << m_angularDistance << endl;
       }
-      
-      if (m_infoStream)
-	m_infoStream << "update frame " <<  m_readingCount << endl
-		     << "update ld=" << m_linearDistance << " ad=" << m_angularDistance << endl;
-      
-      
-      cerr << "Laser Pose= " << reading.getPose().x << " " << reading.getPose().y 
-	   << " " << reading.getPose().theta << endl;
-      
-      
+
+      if (m_infoStream) {
+          m_infoStream << "update frame " << m_readingCount << endl
+                       << "update ld=" << m_linearDistance << " ad=" << m_angularDistance << endl;
+          m_infoStream << "Laser Pose= " << reading.getPose().x << " " << reading.getPose().y
+                       << " " << reading.getPose().theta << endl;
+      }
+
       //this is for converting the reading in a scan-matcher feedable form
       assert(reading.size()==m_beams);
       double * plainReading = new double[m_beams];
@@ -462,9 +477,11 @@ void GridSlamProcessor::setMotionModelParameters
 	  
 	}
       }
-      //		cerr  << "Tree: normalizing, resetting and propagating weights at the end..." ;
+      // if (m_infoStream)
+      //		m_infoStream  << "Tree: normalizing, resetting and propagating weights at the end..." ;
       updateTreeWeights(false);
-      //		cerr  << ".done!" <<endl;
+      // if (m_infoStream)
+      //		m_infoStream  << ".done!" <<endl;
       
       delete [] plainReading;
       m_lastPartPose=m_odoPose; //update the past pose for the next iteration

--- a/include/gmapping/gridfastslam/gridslamprocessor.h
+++ b/include/gmapping/gridfastslam/gridslamprocessor.h
@@ -9,6 +9,7 @@
 #include <gmapping/particlefilter/particlefilter.h>
 #include <gmapping/utils/point.h>
 #include <gmapping/utils/macro_params.h>
+#include "gmapping/utils/nullstream.h"
 #include <gmapping/log/sensorlog.h>
 #include <gmapping/sensor/sensor_range/rangesensor.h>
 #include <gmapping/sensor/sensor_range/rangereading.h>
@@ -127,6 +128,7 @@ namespace GMapping {
     typedef std::vector<Particle> ParticleVector;
     
     /** Constructs a GridSlamProcessor with default params, whose output is routed to a stream.
+     *  To suppress outputs from this node, pass GMapping::g_null_stream for both arguments.
      @param infoStr: (optional) the output stream, default cout
      @param errStr: (optional) the error output stream, default cerr
     */

--- a/include/gmapping/gridfastslam/gridslamprocessor.h
+++ b/include/gmapping/gridfastslam/gridslamprocessor.h
@@ -126,13 +126,11 @@ namespace GMapping {
     
     typedef std::vector<Particle> ParticleVector;
     
-    /** Constructs a GridSlamProcessor, initialized with the default parameters */
-    GridSlamProcessor();
-
-    /** Constructs a GridSlamProcessor, whose output is routed to a stream.
-     @param infoStr: the output stream
+    /** Constructs a GridSlamProcessor with default params, whose output is routed to a stream.
+     @param infoStr: (optional) the output stream, default cout
+     @param errStr: (optional) the error output stream, default cerr
     */
-    GridSlamProcessor(std::ostream& infoStr);
+    GridSlamProcessor(std::ostream& infoStr = std::cout, std::ostream& errStr = std::cerr);
     
     /** @returns  a deep copy of the grid slam processor with all the internal structures.
     */
@@ -305,6 +303,7 @@ namespace GMapping {
 
     // stream in which to write the messages
     std::ostream& m_infoStream;
+    std::ostream& m_errStream;
     
     
     // the functions below performs side effect on the internal structure,

--- a/include/gmapping/gridfastslam/gridslamprocessor.hxx
+++ b/include/gmapping/gridfastslam/gridslamprocessor.hxx
@@ -124,31 +124,37 @@ inline bool GridSlamProcessor::resample(const double* plainReading, int adaptSiz
       deletedParticles.push_back(j);
       j++;
     }
-    //		cerr << endl;
-    std::cerr <<  "Deleting Nodes:";
+    if (m_infoStream)
+      m_infoStream <<  "Deleting Nodes:";
     for (unsigned int i=0; i<deletedParticles.size(); i++){
-      std::cerr <<" " << deletedParticles[i];
+      m_infoStream <<" " << deletedParticles[i];
       delete m_particles[deletedParticles[i]].node;
       m_particles[deletedParticles[i]].node=0;
     }
-    std::cerr  << " Done" <<std::endl;
+    if (m_infoStream)
+      m_infoStream  << " Done" <<std::endl;
     
     //END: BUILDING TREE
-    std::cerr << "Deleting old particles..." ;
+    if (m_infoStream)
+      m_infoStream << "Deleting old particles..." ;
     m_particles.clear();
-    std::cerr << "Done" << std::endl;
-    std::cerr << "Copying Particles and  Registering  scans...";
+    if (m_infoStream) {
+      m_infoStream << "Done" << std::endl;
+      m_infoStream << "Copying Particles and  Registering  scans...";
+    }
     for (ParticleVector::iterator it=temp.begin(); it!=temp.end(); it++){
       it->setWeight(0);
       m_matcher.invalidateActiveArea();
       m_matcher.registerScan(it->map, it->pose, plainReading);
       m_particles.push_back(*it);
     }
-    std::cerr  << " Done" <<std::endl;
+    if (m_infoStream)
+      m_infoStream  << " Done" <<std::endl;
     hasResampled = true;
   } else {
     int index=0;
-    std::cerr << "Registering Scans:";
+    if (m_infoStream)
+      m_infoStream << "Registering Scans:";
     TNodeVector::iterator node_it=oldGeneration.begin();
     for (ParticleVector::iterator it=m_particles.begin(); it!=m_particles.end(); it++){
       //create a new node in the particle tree and add it to the old tree
@@ -168,7 +174,8 @@ inline bool GridSlamProcessor::resample(const double* plainReading, int adaptSiz
       node_it++;
       
     }
-    std::cerr  << "Done" <<std::endl;
+    if (m_infoStream)
+      m_infoStream  << "Done" <<std::endl;
     
   }
   //END: BUILDING TREE

--- a/include/gmapping/utils/nullstream.h
+++ b/include/gmapping/utils/nullstream.h
@@ -1,0 +1,35 @@
+#ifndef NULLSTREAM_H
+#define NULLSTREAM_H
+
+#include <iostream>
+
+namespace GMapping {
+
+/** Null output buffer/stream support.
+ */
+class NullBuffer : public std::streambuf {
+  public:
+    int overflow(int c) {
+        return c;
+    }
+};
+class NullStream : public std::ostream {
+  public:
+    NullStream()
+      : std::ostream(&m_sb) {
+    }
+
+  private:
+    NullBuffer m_sb;
+};
+
+/** Null output stream that can be used to suppress outputs. 
+ *  Passing this into the GridSlamProcessor constructor as
+ *      GridSlamProcessor(GMapping::g_null_stream, GMapping::g_null_stream)
+ *  will effectively suppress all command line output from the class.
+ */
+static NullStream g_null_stream;
+
+}
+
+#endif


### PR DESCRIPTION
# Motivation
The `GridSlamProcessor` class already had a member variable `std::ostream& m_infoStream;` which is used in some places to write console output for logs and general info. This stream can be set through the class' constructor, so users have some control over the output from the class. However, many functions in this class were writing directly to `std::cerr` instead, which cannot be controlled without modifying the code itself.

# Description
This PR generalizes uses of `cerr` in `gridslamprocessor.cpp` to use `m_infoStream` or a new member variable `m_errStream`. Most of the `cerr` statements seemed more informative than error-based, so most have been changed to use the former.

The class constructor now accepts two optional arguments, `infoStr` and `errStr`, which default to `std::cout` and `std::cerr` respectively. I have combined the existing two constructors into this new one by using optional arguments.

Finally, I have introduced a new utility file `nullstream.h`, containing a class definition and a global/static variable `g_null_stream`. When constructing the class, a user can pass this argument for `infoStr` and/or `errStr` to effectively suppress console output from `GridSlamProcessor`.
(I would be fine reverting the nullstream addition if y'all would prefer to merge the previously mentioned ostream generalizations on their own. This was just kind of annoying to get working, so I figured I'd add it for others to use too.)

# Testing
This change should have no effect on the performance itself, and other than some things printing to `cout` instead of `cerr` by default, the console output will not change by default. New behavior is only achieved by a runner class modifying its constructor call.

I have tested this on our usage of the `GridSlamProcessor` in our own code, and see all the usual console outputs when constructing the class with
```
std::unique_ptr<GMapping::GridSlamProcessor> m_gsp = std::make_unique<GMapping::GridSlamProcessor>();
```
or
```
std::unique_ptr<GMapping::GridSlamProcessor> m_gsp = std::make_unique<GMapping::GridSlamProcessor>(std::cout, std::cerr);
```
and am able to run it just the same, but without any console outputs, with
```
std::unique_ptr<GMapping::GridSlamProcessor> m_gsp = std::make_unique<GMapping::GridSlamProcessor>(GMapping::g_null_stream, GMapping::g_null_stream);
```
